### PR TITLE
Adding hyperlink support

### DIFF
--- a/app/Components/JSONView/JBlock/index.tsx
+++ b/app/Components/JSONView/JBlock/index.tsx
@@ -10,7 +10,7 @@ const JBlock = ({ children, collapsible, onArrowClick, active, copyData }) => {
   const events = React.useContext(EventContext);
 
   const handleSectionClick = (e: MouseEvent) => {
-    e.preventDefault();
+    // e.preventDefault();
     e.stopPropagation();
 
     setSelected(!selected);

--- a/app/Components/JSONView/JString/index.tsx
+++ b/app/Components/JSONView/JString/index.tsx
@@ -11,12 +11,24 @@ const JString = ({ label, value, isLast }) => {
       )}
       {value === null ? (
         <span className="null">null</span>
-      ) : (
-        <span className="string">"{value}"</span>
-      )}
+      ) : isValidHttpUrl(value) ? (
+        <span className="hyperlink">"<a href={String(value)} target='_blank'>{value}</a>"</span>
+      ) : <span className="string">"{value}"</span>}
       {!isLast && ','}
     </section>
   );
 };
+
+function isValidHttpUrl(string) {
+  let url;
+  
+  try {
+    url = new URL(string);
+  } catch (_) {
+    return false;  
+  }
+
+  return url.protocol === "http:" || url.protocol === "https:";
+}
 
 export { JString };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@types/chrome": "^0.0.96",
     "jsonpath": "^1.0.2",
     "jsonpath-plus": "^3.0.0",
-    "parcel-bundler": "^1.12.4",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "react-icons": "^3.9.0",
@@ -24,6 +23,7 @@
     "typescript": "^3.7.5"
   },
   "devDependencies": {
+    "parcel-bundler": "^1.12.3",
     "sass": "^1.25.0"
   }
 }

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -3,6 +3,7 @@
   --accent-color: #00cc7d;
   --accent-color-light: #00cc7e69;
   --string-color: #d69d85;
+  --hyperlink-color: #43beee;
   --number-color: #b5cea8;
   --boolean-color: #4ec9b0;
   --label-color: #569cd6;
@@ -78,6 +79,14 @@ body {
   .string {
     color: var(--string-color);
   }
+
+  .hyperlink {
+    color: var(--hyperlink-color);
+  }
+
+  .hyperlink a{ 
+    color: var(--hyperlink-color);
+ }
 
   .boolean {
     color: var(--boolean-color);


### PR DESCRIPTION
# Hyperlink support for Seven JSON Viewer 🔗

#### @reezpatel Congrats on making such a wonderful extension! I have certainly enjoyed using it. 🎉

I noticed in your README you are open to contributors via fork. I thought it would be useful to add hyperlink support to the JSON viewer. I often find myself wishing I could click on the hyperlinks in the JSON I view.

I have implemented this functionality in this PR. If this is something you would like to add, please review to see if my implementation could be expanded upon/improved. If you'd like please check for style and implementation. Let me know if there is anything I should tweak.

### Preview

---

![before-after-hyperlinks-seven-json-viewer](https://user-images.githubusercontent.com/24496327/111227595-2e781e00-85b9-11eb-899c-dfd8586a7f12.png)
**Clicking the hyperlink will open the link in a new tab.**

---

### Changes 

- Added a function in JString/index.tsx to check
if a particular input value was a valid hyperlink.

- Added hyperlink color to style.scss hex value of `#43beee `
  (considering changing to something more complementary to the general theme in case there are any suggestions here)

- In JBlock/index.tsx on line 13, I commented out e.preventDefault() in
order to allow for the event handler to accept the hyperlink clicks. **Please let me know if this will have negative consequences that may propagate as a result of this change. I have not experienced any issues so far.** 

- **Note:** I experienced an error upon trying to build the project [detailed here](https://github.com/babel/babel/issues/12945#partial-discussion-header:~:text=Invalid%20Version%3A%20undefined%20in%20preset%2Denv%20%2F%20semver%20after%20updating%20to%207.13.9). I needed to follow [these steps](https://github.com/babel/babel/issues/12945#issuecomment-797164542-permalink:~:text=3%20days%20ago-,I%20have%20the%20same%20SemVer%20issue%20after%20installing%20parcel%401.12.4.,npm%20i%20%2D%2Dsave%2Ddev%20parcel%2Dbundler%401.12.3,-%F0%9F%91%8://github.com/babel/babel/issues/12945#issuecomment-797164542-permalink:~:text=3%20days%20ago-,I%20have%20the%20same%20SemVer%20issue%20after%20installing%20parcel%401.12.4.,npm%20i%20%2D%2Dsave%2Ddev%20parcel%2Dbundler%401.12.3,-%F0%9F%91%8D) to resolve which effetively reverted the parcel-bundler to parcel-bundler@1.12.3. Apparently, there is an ongoing issue with the previous version of parcel-bundler being used for this project. See the isssue that was open at the time of this commit https://github.com/parcel-bundler/parcel/issues/5943.