### PR TITLE
Upgraded to Manifest V3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
   "name": "Seven JSON Viewer",
   "description": "Minimal JSON Viewer with JSON Path",
   "short_name": "JSON Viewer",
-  "version": "3.0",
+  "version": "4.0",
   "offline_enabled": true,
-  "manifest_version": 2,
+  "manifest_version": 3,
   "content_scripts": [
     {
       "matches": ["http://*/*", "https://*/*"],
@@ -13,22 +13,18 @@
       "all_frames": true
     }
   ],
-  "content_security_policy": "sandbox allow-scripts; script-src 'self'; object-src 'none';",
+  "content_security_policy": {
+    "sandbox": "sandbox allow-scripts; script-src 'self'; object-src 'none';"
+  },
   "permissions": ["tabs", "activeTab", "storage"],
-  "web_accessible_resources": ["styles.css", "app.js"],
+  "web_accessible_resources": [{
+    "resources": ["styles.css"],
+    "matches": ["<all_urls>"]
+  }],
   "icons": {
     "16": "assets/icon-16.png",
     "48": "assets/icon-48.png",
     "128": "assets/icon-128.png",
     "512": "assets/icon-512.png"
-  },
-  "browser_action": {
-    "default_popup": "index.html",
-    "default_icon": {
-      "16": "assets/icon-16.png",
-      "48": "assets/icon-48.png",
-      "128": "assets/icon-128.png",
-      "512": "assets/icon-512.png"
-    }
   }
 }


### PR DESCRIPTION
With the Manifest V2 getting phased out in January 2023 (https://developer.chrome.com/docs/extensions/mv3/mv2-sunset/), this will make this extension compatible with the Chrome Extension Store.